### PR TITLE
詳細機能追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -19,7 +19,9 @@ class ItemsController < ApplicationController
     end
   end
 
-  
+  def show
+  end
+
 
   private
 

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -131,11 +131,11 @@
       <% @items.each do |item| %>
 
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id)  do %>
         <div class='item-img-content'>
       <%= image_tag item.image.variant(resize: '500x500'), class: "item-img" if item.image.attached? %>
       
-          <div class='sold-out'>
+         <%# <div class='sold-out'>
             <span>Sold Out!!</span>
           </div>
          <%# //商品が売れていればsold outを表示しましょう %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -8,11 +8,11 @@
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
-      <% if Order.exists?(item_id: @item.id) %>
-        <div class="sold-out">
+    <%# 商品が売れている場合は、sold outを表示しましょう 
+      <%#   <div class="sold-out">
           <span>Sold Out!!</span>
-        </div>
-      <% end %>
+        </div> %>
+    
     </div>
     <div class="item-price-box">
       <span class="item-price">
@@ -23,16 +23,16 @@
       </span>
     </div>
 
-    <% if user_signed_in? %>
-      <% unless Order.exists?(item_id: @item.id) %>
+  <% if user_signed_in? %>
+     
         <% if current_user.id == @item.user_id %>
-          <%= link_to "商品の編集", edit_item_path(@item.id), method: :get, class: "item-red-btn" %>
+          <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
           <p class="or-text">or</p>
-          <%= link_to "削除", item_path(@item.id), data: { turbo_method: :delete }, class:"item-destroy" %>
+          <%= link_to "削除", "#", data: { turbo_method: :delete }, class:"item-destroy" %>
         <% else %>
-          <%= link_to "購入画面に進む", item_orders_path(@item.id) ,class:"item-red-btn"%>
+          <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
         <% end %>
-      <% end %>
+      
     <% end %>
 
     <div class="item-explain-box">


### PR DESCRIPTION
WHAT
商品詳細表示機能の導入

WHY
商品詳細を表示できるようにするため
商品の詳細情報を見れるようにするため

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/dae9e0bc67a8e835a071d427164b32bc

ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/2cdf1d968a6d30be8374b7337d41cce1

ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
まだ未実装


ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/5e246bf862028b2cb86edda20db1c4b3
